### PR TITLE
Mehdi dev

### DIFF
--- a/Drakefile
+++ b/Drakefile
@@ -1,16 +1,25 @@
 ; Configuration Settings
 PARALLEL_THREADS=4
 HIDDEN_LAYER_SIZE=100
-
-INPUT_DATA_DIR=jazz
-OUTPUT_MODEL_NAME=jazz_1
+INPUT_DATA_DIR=medical_corpus
+SEARCH_RESULTS=5
+OUTPUT_MODEL_NAME=medical_model
 
 ; Don't change this
 FUN_3000_DIR=fun_3000
 
-workflow/00.model.complete <- data/$[INPUT_DATA_DIR]/workflow.start [shell]
+; Start of Steps
+workflow/00.build_corpus.complete <- data/eval_data.txt [shell]
     mkdir -p workflow/
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        search_term=${line// /_}
+        search_term=${line//\//_}
+        python $[FUN_3000_DIR]/ingestion/wikipedia_ingest.py -s $search_term -r $[SEARCH_RESULTS] -d $[INPUT_DATA_DIR]
+    done < $INPUT
+    touch $OUTPUT
+
+workflow/01.model.complete <- workflow/00.build_corpus.complete [shell]
     python $[FUN_3000_DIR]/word2vec.py -i $[INPUT_DATA_DIR] -o $[OUTPUT_MODEL_NAME] -p $[PARALLEL_THREADS] -l $[HIDDEN_LAYER_SIZE] && touch $OUTPUT
 
-workflow/01.evaluate.complete <- workflow/00.model.complete [shell]
+workflow/02.evaluate.complete <- workflow/01.model.complete [shell]
     echo 'Evaluation complete.' && touch $OUTPUT

--- a/fun_3000/ingestion/wikipedia_ingest.py
+++ b/fun_3000/ingestion/wikipedia_ingest.py
@@ -40,7 +40,6 @@ def main():
         makedirs(model_data_dir)
 
     if search_term is not None:
-        logging.info('Searching for Wiki pages...')
         wiki_results = src(search_term, results)
 
         for result in wiki_results:

--- a/fun_3000/ingestion/wikipedia_ingest.py
+++ b/fun_3000/ingestion/wikipedia_ingest.py
@@ -1,4 +1,4 @@
-from wikipedia import page as wpg
+from wikipedia import page as wpg, search as src
 from os import path, pardir, makedirs
 
 import logging
@@ -19,10 +19,12 @@ def main():
     parser = optparse.OptionParser()
     parser.add_option('-s', '--search_term', dest='search_term', default=None, type='string', help='Specify the wikipedia search term (Default is "Disease")')
     parser.add_option('-d', '--data_directory', dest='data_directory', default=None, help='Specify a directory name for saving search data')
+    parser.add_option('-r', '--results', dest='results', default=1, help='Specify the number of search results to be returned by Wikipedia')
     (opts, args) = parser.parse_args()
 
     search_term = opts.search_term
     data_directory = opts.data_directory
+    results = opts.results
 
     current_dir = path.dirname(path.realpath(__file__))
     parent_dir = path.abspath(path.join(current_dir, pardir))
@@ -38,9 +40,13 @@ def main():
         makedirs(model_data_dir)
 
     if search_term is not None:
-        logging.info('Retrieving "%s" page from Wikipedia.' % (search_term))
-        local_file_path = model_data_dir + '/model_data.txt'
-        save_wiki_text(search_term, local_file_path)
+        logging.info('Searching for Wiki pages...')
+        wiki_results = src(search_term, results)
+
+        for result in wiki_results:
+            logging.info('Retrieving "%s" page from Wikipedia.' % (result))
+            local_file_path = model_data_dir + '/' + result.replace('/', '_') + '.txt'
+            save_wiki_text(search_term, local_file_path)
     else:
         logging.info('You have not specified a search term!')
 


### PR DESCRIPTION
This resolves #8 

We currently have a script that takes a search term and fetches the text of the corresponding page from Wikipedia. The desired behavior is to have this script not only get the page specified by the search term, but also a number of other pages from the list of related results provided by Wikipedia.

Practically speaking, let's say I'm looking to build a corpus about medicine and I have provide the search term 'Aspirine' to the wikipedia search:
- Current behavior: the script gets the text of the Aspirine page and saves it in a file called model.txt
- New behavior: the script gets the text of the Aspirine page and saves it in a file called Aspirine.txt. It also fetches K additional related page results and saves each of them as <related_page_title>.txt (E.g. Tylenol.txt, Pain_Killers.txt, Acetaminophen.txt, etc.)

K is an optional parameter specified by the user. The default value is 1.

Usage example:

`python fun_3000/ingestion/wikipedia_ingest.py -s 'Basketball' -d 'Sports' -r 5`

This should result in 5 files created as follows:

```
fun_3000/
|__ data/
      |__ Sports/
            |__ Basketball.txt
            |__ List of Basketball Leagues.txt
            |__ Point (basketball).txt
            |__ List of Philippine Basketball Association players.txt
            |__ College basketball.txt
```
