### PR TITLE
closes #45. Fix some bugs on wikipedia ingestion

### DIFF
--- a/fun_3000/get_corpus.py
+++ b/fun_3000/get_corpus.py
@@ -38,9 +38,8 @@ def fetch_corpus(search_terms, data_dir, results):
 
 	for term in search_terms:
 		wiki_search.get_wikipedia_pages(term, data_dir, results)
-		logging.info('Fetched %s term wiki artifacts.' % term)
 		med_search.get_medical_abstracts(term, data_dir, results)
-		logging.info('Fetched %s term medical abstract artifacts.' % term)
+
 
 
 def fetch_books(directory):

--- a/fun_3000/ingestion/med_abstract_ingest.py
+++ b/fun_3000/ingestion/med_abstract_ingest.py
@@ -183,6 +183,7 @@ def get_medical_abstracts(search_term, data_directory, results=1):
         medline_url =  medline_search_url.replace('<SEARCH_TERM>', search_term).replace('<RESULTS>', str(results))
         abstracts_medline = fetch_medline(medline_url.rstrip())
         save_file(local_file_path, abstracts_medline)
+        logging.info('Fetched %s term medical abstract artifacts.' % search_term)
 
     else:
         logging.info('You have not specified a search term!')

--- a/fun_3000/ingestion/wikipedia_ingest.py
+++ b/fun_3000/ingestion/wikipedia_ingest.py
@@ -55,7 +55,6 @@ def get_wikipedia_pages(search_term, data_directory, results=1):
         else:
             logging.info('You have not specified a search term!')
     except (PageError, DisambiguationError) as e:
-        print dir(e)
         logging.info("Skipping download for term %s, received error %s" %(search_term, type(e)))
 
 


### PR DESCRIPTION
Closes #45. Catching PageErrors and DisambiguationErrors when we search in Wikipedia since it was crashing our corpus ingestions. Moving logging closer to actual save so that the script doesn't oddly report that something was 'fetched' when it actually caught and passed out of the except block. Turn auto_suggest off for now since it might give us weird results; changing this didn't actually help with the Malignant tumor of lung/Malignant tumor of luna problem in terms of preventing the PageError exception but does prevent wikipedia from trying to find results that aren't exactly what we ask for.
