### PR TITLE
Python3 compat

### DIFF
--- a/fun_3000/evaluation/similarity_evaluation.py
+++ b/fun_3000/evaluation/similarity_evaluation.py
@@ -6,6 +6,7 @@ from sklearn.cross_validation import cross_val_score
 import optparse
 import time
 import csv
+import io
 
 class FEATURE_BUILDER():
     '''
@@ -199,7 +200,7 @@ if __name__ == '__main__':
 
     score_final = full_cross_validated_score(opts.train_run, opts.k)
 
-    with open(opts.output, 'a') as output_file:
+    with io.open(opts.output, 'at') as output_file:
         output_writer = csv.writer(output_file)
         output_writer.writerow([opts.train_run, score_final, time.strftime("%H:%M:%S"), time.strftime("%d/%m/%Y")])
 

--- a/fun_3000/get_corpus.py
+++ b/fun_3000/get_corpus.py
@@ -15,7 +15,7 @@ def import_terms(filename):
 	'''
 	search_terms = []
 
-	with open(filename, 'rb') as f:
+	with open(filename, 'r') as f:
 		reader = csv.reader(f)
 		for row in reader:
 			search_terms.extend(row)

--- a/fun_3000/get_corpus.py
+++ b/fun_3000/get_corpus.py
@@ -15,7 +15,7 @@ def import_terms(filename):
 	'''
 	search_terms = []
 
-	with open(filename, 'r') as f:
+	with io.open(filename, 'rb') as f:
 		reader = csv.reader(f)
 		for row in reader:
 			search_terms.extend(row)

--- a/fun_3000/ingestion/ingest_ontologies.py
+++ b/fun_3000/ingestion/ingest_ontologies.py
@@ -3,6 +3,7 @@ from copy import copy
 from os import path, pardir, makedirs
 import optparse
 import logging
+import io
 
 def ingest_and_wrangle_owls(data_directory):
     """
@@ -58,7 +59,7 @@ def ingest_and_wrangle_owls(data_directory):
                             FILTER (isIRI(?o)).
                             ?o rdfs:label ?label} """
             # write it down
-            with open(path.join(output_dir, name+".txt"), "w") as writer:
+            with io.open(path.join(output_dir, name+".txt"), "wt") as writer:
                 for row in g.query(query):
                     # save these triples somewhere
                     writer.write("{s} {p} {o}\n".format(s=row[0], p="is", o=row[1]))

--- a/fun_3000/ingestion/ingest_ontologies.py
+++ b/fun_3000/ingestion/ingest_ontologies.py
@@ -66,7 +66,7 @@ def ingest_and_wrangle_owls(data_directory):
         except: #if does not exist then log it!
             logging.warning('Could not locate %s' % location)
 
-        print logging.info('Ontology %s of %s complete.' % (str(progress), len(other_ontologies)))
+        print(logging.info('Ontology %s of %s complete.' % (str(progress), len(other_ontologies))))
 
 
 if __name__=='__main__':

--- a/fun_3000/word2vec.py
+++ b/fun_3000/word2vec.py
@@ -103,7 +103,7 @@ def run_model_fold(input_data_dir, model_data_dir, this_model_dir, parallel_work
     else:
         model_path = this_model_dir + '/' + model_name + '.model'
 
-    print model_path
+    print(model_path)
     model.save(model_path)
 
 if __name__ == '__main__':

--- a/fun_3000/word2vec.py
+++ b/fun_3000/word2vec.py
@@ -5,6 +5,7 @@ import optparse
 import logging
 import time
 from os import path, listdir
+import io
 
 logging.basicConfig(format='%(asctime)s: %(levelname)s : %(message)s', level=logging.INFO)
 
@@ -15,7 +16,8 @@ class MySentences(object):
 
     def __iter__(self):
         for input_file_name in listdir(self.dirname):
-            for line in open(path.join(self.dirname, input_file_name)):
+            for line in io.open(path.join(self.dirname, input_file_name), 'rb'):
+                # explicitly loading as binary in python 2x and 3x. should at this point be ascii encoded
                 yield line.split()                                             
 
 def timeit(method):

--- a/fun_3000/wrangling/clean_corpus.py
+++ b/fun_3000/wrangling/clean_corpus.py
@@ -1,5 +1,6 @@
 import re
 import optparse
+import io
 
 
 def clean_corpus(corpus):
@@ -86,13 +87,14 @@ if __name__ == '__main__':
     parser.add_option('-s', '--min_sentence_length', dest='sentence_length', default=10, help="Specify minimum sentence word length.")
     (opts, args) = parser.parse_args()
 
-    with open(opts.input_file, "r") as f:
+    with io.open(opts.input_file, "rb") as f:
+        # expecting binary or mixed binary/text
         corpus = f.read()
 
     cleaned_corpus = clean_corpus(corpus)
     tokenized_corpus = tokenize_sentences(cleaned_corpus)
     cleaned_sentences = validate_sentences(tokenized_corpus, opts.sentence_length)
 
-    with open(opts.output_file, "w") as f:
+    with io.open(opts.output_file, "wt") as f:
         blob = ' '.join(cleaned_sentences)
         f.write(blob)

--- a/fun_3000/wrangling/clean_corpus.py
+++ b/fun_3000/wrangling/clean_corpus.py
@@ -10,7 +10,7 @@ def clean_corpus(corpus):
     :return: cleaned corpus string
     :rtype: str
     '''
-    corpus = corpus.decode(encoding='ascii', errors='ignore')  # force drop all non-ascii characters like copyright symbols
+    corpus = corpus.encode(encoding='ascii', errors='ignore').decode(encoding='ascii', errors='ignore')  # force drop all non-ascii characters like copyright symbols
     corpus = re.sub(r'<.*?>', ' ', corpus)  # html tags
     corpus = re.sub(r'{.*?}', ' ', corpus)  # anything between brackets, from latex in medical abstracts
     corpus = re.sub(r'${.*?}', ' ', corpus)  # any line leading content between brackets, from latex in medical abstracts

--- a/fun_3000/wrangling/clean_corpus.py
+++ b/fun_3000/wrangling/clean_corpus.py
@@ -86,13 +86,13 @@ if __name__ == '__main__':
     parser.add_option('-s', '--min_sentence_length', dest='sentence_length', default=10, help="Specify minimum sentence word length.")
     (opts, args) = parser.parse_args()
 
-    with open(opts.input_file, "rb") as f:
+    with open(opts.input_file, "r") as f:
         corpus = f.read()
 
     cleaned_corpus = clean_corpus(corpus)
     tokenized_corpus = tokenize_sentences(cleaned_corpus)
     cleaned_sentences = validate_sentences(tokenized_corpus, opts.sentence_length)
 
-    with open(opts.output_file, "wb") as f:
+    with open(opts.output_file, "w") as f:
         blob = ' '.join(cleaned_sentences)
         f.write(blob)

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -101,7 +101,7 @@ def store_file(folds_dict, run_directory):
             makedirs(portion_dir)
         fold_file = path.join(portion_dir, portion + '.txt')
 
-        with open(fold_file,'wb') as outfile:
+        with open(fold_file,'w') as outfile:
             outfile.write(fold[portion])
 
     current_dir = path.dirname(path.realpath(__file__))

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -161,7 +161,7 @@ def read_source(run_directory, source_type):
         return input_data
 
     else:
-        print 'Could not find the data/ontology directory: ', data_dir
+        print('Could not find the data/ontology directory: ', data_dir)
         sys.exit(0)
 
 

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -154,7 +154,7 @@ def read_source(run_directory, source_type):
     if path.exists(data_dir):
         for some_corpus_file in listdir(data_dir):
             if path.isfile(path.join(data_dir, some_corpus_file)):
-                with open(path.join(data_dir, some_corpus_file),'rb') as infile:
+                with open(path.join(data_dir, some_corpus_file),'r') as infile:
                     new_file_data = infile.read()
                     input_data = ''.join((input_data, new_file_data))
 

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -1,6 +1,6 @@
 from sklearn.cross_validation import KFold
 from os import path, makedirs, listdir
-import re
+import io
 import numpy as np
 import optparse
 import sys
@@ -101,7 +101,7 @@ def store_file(folds_dict, run_directory):
             makedirs(portion_dir)
         fold_file = path.join(portion_dir, portion + '.txt')
 
-        with open(fold_file,'w') as outfile:
+        with io.open(fold_file,'wt') as outfile:
             outfile.write(fold[portion])
 
     current_dir = path.dirname(path.realpath(__file__))
@@ -154,8 +154,11 @@ def read_source(run_directory, source_type):
     if path.exists(data_dir):
         for some_corpus_file in listdir(data_dir):
             if path.isfile(path.join(data_dir, some_corpus_file)):
-                with open(path.join(data_dir, some_corpus_file),'r') as infile:
+                with io.open(path.join(data_dir, some_corpus_file),'rb') as infile:
+                    # read as bytes. should be utf-8 but we have had corrupted or utf-16 before
                     new_file_data = infile.read()
+                    # force decode to ascii, dropping errors
+                    new_file_data = new_file_data.decode(encoding='ascii', errors='ignore')
                     input_data = ''.join((input_data, new_file_data))
 
         return input_data


### PR DESCRIPTION
I started making this python 3 compat since @lcombs was on a 3.x anaconda distribution. Right now the changes are
- print statements->print function lolol
- File opening is now totally different in python 3.x series. ~~In this PR any `open()` function calls are called with 'r' or 'w' mode instead of 'rb' or 'wb'. [In python 3.x](https://docs.python.org/3/library/functions.html#open), 'rb' and 'wb' now explicitly mean read as a `BytesIO` object, while 'r' (implicitly 'rt') and 'w' (implicitly 'wt)) mean read as a `TextIO` object (which means it does the `str` conversion for you on read). In python 2.x series, the `open()` function instantiated a `file` object, whose [read method](https://docs.python.org/2.7/library/stdtypes.html#file.read) implicitly decoded the underlying bytestream to `str`. So the TextIO behavior is more similar to what we used to do. If we want, we can read them in a `BytesIO` and decode them ourselves, but given that python 3.x series default encoding is now UTF-8 I'm don't think that's necessary.~~ So actually instead I now converted all of the `open()` calls to explicitly use `io.open()` (which is the default for python 3.x series for `open()`) so that both styles use the same interface. I explicitly load as binary or text at each call; most importantly during the generate_folds script, I load as binary and force downconvert to ascii encoding as we normally would do later during the clean_corpus steps.

~~Surprisingly since 'rb' and 'wb' mode in python 2.x series probably didn't do anything useful for us given that we called the `.read()` method anyways, this may still be 2.x compatible.~~
