### PR TITLE
Closes #55 parameterize boost mode

### DIFF
--- a/Drakefile
+++ b/Drakefile
@@ -32,4 +32,4 @@ workflow/02.model.complete <- workflow/01.generate_folds.complete [shell]
 
 ; Run Evaluation
 workflow/03.evaluate.complete <- workflow/02.model.complete [shell]
-    python $[FUN_3000_DIR]/evaluation/similarity_evaluation.py -r $[INPUT_DATA_DIR] -f $[FOLDS] -o $[SCORING_OUTPUT_FILE] && touch $OUTPUT
+    python $[FUN_3000_DIR]/evaluation/similarity_evaluation.py -r $[INPUT_DATA_DIR] -f $[FOLDS] -o $[SCORING_OUTPUT_FILE] -m $[MULTIPLIER] && touch $OUTPUT

--- a/Drakefile
+++ b/Drakefile
@@ -9,6 +9,7 @@ FOLDS=3
 SEED=10
 
 ; General Configuration
+MULTIPLIER=10
 INPUT_DATA_DIR=run1
 SEARCH_RESULTS=5
 SCORING_OUTPUT_FILE=scores.csv
@@ -23,7 +24,7 @@ workflow/00.setup.complete <- [shell]
 
 ; Clean data, generate folds, and place in the proper file structure.
 workflow/01.generate_folds.complete <- workflow/00.setup.complete [shell]
-    python $[FUN_3000_DIR]/wrangling/generate_folds.py -d $[INPUT_DATA_DIR] -k $[FOLDS] -o -s $[SEED] && touch $OUTPUT
+    python $[FUN_3000_DIR]/wrangling/generate_folds.py -d $[INPUT_DATA_DIR] -k $[FOLDS] -o -s $[SEED] -m $[MULTIPLIER] && touch $OUTPUT
 
 ; Run Gensim word2vec on each fold
 workflow/02.model.complete <- workflow/01.generate_folds.complete [shell]

--- a/fun_3000/evaluation/similarity_evaluation.py
+++ b/fun_3000/evaluation/similarity_evaluation.py
@@ -195,13 +195,14 @@ if __name__ == '__main__':
     parser.add_option('-r', '--training_run', dest='train_run', default='', help='Specify training run to test.')
     parser.add_option('-f', '--folds', dest='k', default=3, help='Specify number of folds in training run', type='int')
     parser.add_option('-o', '--output_file', dest='output', default='scores.csv',help='File to store model score for run.')
+    parser.add_option('-m', '--multiplier', dest='multiplier', help="What multiplier for the ontology boost was used for these models we are evaluating.")
     (opts, args) = parser.parse_args()
 
     score_final = full_cross_validated_score(opts.train_run, opts.k)
 
     with open(opts.output, 'a') as output_file:
         output_writer = csv.writer(output_file)
-        output_writer.writerow([opts.train_run, score_final, time.strftime("%H:%M:%S"), time.strftime("%d/%m/%Y")])
+        output_writer.writerow([opts.train_run, score_final, time.strftime("%H:%M:%S"), time.strftime("%d/%m/%Y"),opts.multiplier])
 
 
 


### PR DESCRIPTION
## Background

Closes #55. Provides a way to specify during the Drakefile how much to 'boost' the ontologies by multiplying them on each corpus fold during `generate_folds.py`.
## Implementation Notes

Basically does a bunch of forwarding of a int to multiply by through all the levels e.g. Drakefile -> wrapper script -> actual function that does the work. Updated some docstrings as well, and there was an inaccurate if statement in there comparing a bool to the string `'True'` that got changed as well (turns out on develop right now, ontologies don't even get appended as a result of that snafu lol).
## Testing

Here's how I tested it:
1. Took the top 5 files from the S3 corpus dump and put them in data/run1 (so I didn't have to spend a long time waiting for the whole drakefile to finish)
2. Ran basically all the following stuff. It's important to note for these numbers to add up that during `generate_folds.py`, the structure of the finalized corpus file is a single text file (e.g. train.txt) that has on line 1 the cleaned up and concatenated natural language source corpus and the first ontology sentence, and then all the other ontology sentences separated by new lines. 

``` bash
(ddl_nlp)run1 $ pwd
/Users/llorenz/Development/ddl/ddl_nlp/ontologies/run1
(ddl_nlp)run1 $ ls 
biomedical_investigations.txt   infectious_disease.txt
# see we have two ontologies. below we have the first line
(ddl_nlp)run1 $ head -n1 biomedical_investigations.txt 
_obsolete_incubation period is Obsolete Class
(ddl_nlp)run1 $ grep -r "_obsolete_incubation period is Obsolete Class" . # you see this specific line is actually in both of them
./biomedical_investigations.txt:_obsolete_incubation period is Obsolete Class
./infectious_disease.txt:_obsolete_incubation period is Obsolete Class
#  now let's check out this branch
(ddl_nlp)train $ git checkout 55-parameterize-boost-mode
Switched to branch '55-parameterize-boost-mode'
Your branch is up-to-date with 'origin/55-parameterize-boost-mode'.
(ddl_nlp)ddl_nlp $ pwd
/Users/llorenz/Development/ddl/ddl_nlp
# the Drakefile is set to multiplier 1 aka no multiplying of the ontologies
(ddl_nlp)ddl_nlp $ head -n 12 Drakefile 
; Configuration Settings

; Gensim Configuration
PARALLEL_THREADS=4
HIDDEN_LAYER_SIZE=100

; Folds Configuration
FOLDS=3
SEED=10

; General Configuration
MULTIPLIER=1
(ddl_nlp)ddl_nlp $ drake --quiet
The following steps will be run, in order:
  1: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/00.setup.complete <-  [no-input step]
  2: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/01.generate_folds.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/00.setup.complete [projected timestamped]
  3: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/02.model.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/01.generate_folds.complete [projected timestamped]
  4: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/03.evaluate.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/02.model.complete [projected timestamped]
Confirm? [y/n] y
[..] # skipping word2vec output
(ddl_nlp)ddl_nlp $ cat data/run1/1/train/train.txt | wc
    4427   44531  332000
# so there's 4427 lines in train if multiplier is 1
(ddl_nlp)ddl_nlp $ head scores.csv 
run1,-0.285965716405993,21:19:47,27/10/2016,1
# we store the multiplier information at the end of the scores.csv line
# ok now look at the Drakefile I edited to have multiplier of 10. we'll multiply the ontologies 10 times now
(ddl_nlp)ddl_nlp $ head -n 12 Drakefile 
; Configuration Settings

; Gensim Configuration
PARALLEL_THREADS=4
HIDDEN_LAYER_SIZE=100

; Folds Configuration
FOLDS=3
SEED=10

; General Configuration
MULTIPLIER=10
(ddl_nlp)ddl_nlp $ drake --quiet
The following steps will be run, in order:
  1: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/00.setup.complete <-  [no-input step]
  2: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/01.generate_folds.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/00.setup.complete [projected timestamped]
  3: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/02.model.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/01.generate_folds.complete [projected timestamped]
  4: /Users/llorenz/Development/ddl/ddl_nlp/././workflow/03.evaluate.complete <- /Users/llorenz/Development/ddl/ddl_nlp/././workflow/02.model.complete [projected timestamped]
Confirm? [y/n] y
[..] # skipping word2vec output
(ddl_nlp)ddl_nlp $ cat data/run1/1/train/train.txt | wc
   44270  384227 2914676
# now it's times 10!
(ddl_nlp)ddl_nlp $ head scores.csv 
run1,-0.285965716405993,21:19:47,27/10/2016,1
run1,-0.35699637168912607,21:20:47,27/10/2016,10
(ddl_nlp)ddl_nlp $ grep "_obsolete_incubation period is Obsolete Class" data/run1/1/train/train.txt | wc
      20    6887   45965
# we can see that this one line we were interested in is now 20 times (because it was in each ontology once (2) and we multiplied it by 10)
```
