### PR TITLE
Closes #54 clean corpus ahead of folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ continue to tweak your ml parameters and re-run the drake workflow to run the en
     - [Medical abstracts](#medical-abstracts)
     - [Medical textbooks](#medical-textbooks)
     - [Ontologies](#ontologies)
+   - [Cleaning Corpus](#cleaning-corpus)
 - [Model Building](#model-building)
     - [To generate data-folds](#to-generate-data-folds)
     - [Cleaning text](#cleaning-text)
@@ -157,6 +158,27 @@ ontology_grab.ingest_and_wrangle_owls(directory)
 
 You can also run the ontology ingestion module directly as a script; see usage notes in the script itself.
 
+#### Cleaning corpus
+
+To clean the corpus, use the `wrangling/clean_corpus.py` script. This script can clean a single file, or a directory's worth of files into a single, newline delimited text file that cleans up certain types of characters or phrases and splits the data into sentences of a minimum length.
+
+The common use will be to use this script to clean a directory's worth of files. In that case, the cleaned and concatednated file (by defualt `output.txt`) will be located in the same directory the individual files were in.
+
+##### Details on what is cleaned from the corpus
+
+There are several functions called during the generate folds process before and after the sentences are tokenized to remove HTML and Latex code, formatting, headers, and other potentially bothersome elements from the text.
+
+Full list of stuff that is removed, by default:
+
+* Remove all html tags {<-->)
+* Remove all latex ({--} and ${--})
+* Remove headers from wikipedia articles
+* Remove new lines and carriage returns (this messes up the tokenize script)
+* Remove all non-ascii characters (like copyright symbols)
+* Remove extraneous spaces (this also messes up the tokenize script)
+* Remove sentences less than 10 words long (or some length defined in parameter), that don't end with a period, don't start with a capital letter, or start with a number
+
+
 ## Model Building
 
 ### To generate data-folds
@@ -200,21 +222,6 @@ where:
 - `-o` is a boolean flag indicating whether we are including an ontology in this run.
 - `-d` is the data directory for this test run, for example 'run1'
 - `-s` is the random seed
-
-#### Cleaning text
-
-There are several functions called during the generate folds process before and after the sentences are tokenized to remove HTML and Latex code, formatting, headers, and other potentially bothersome elements from the text.
-
-Full list of stuff that is removed:
-
-* Remove all html tags {<-->)
-* Remove all latex ({--} and ${--})
-* Remove headers from wikipedia articles
-* Remove new lines and carriage returns (this messes up the tokenize script)
-* Remove all non-ascii characters (like copyright symbols)
-* Remove extraneous spaces (this also messes up the tokenize script)
-* Remove sentences less than 10 words long (or some length defined in parameter), that don't end with a period, don't start with a capital letter, or start with a number
-
 
 ### To create a model:
 

--- a/fun_3000/wrangling/clean_corpus.py
+++ b/fun_3000/wrangling/clean_corpus.py
@@ -1,5 +1,7 @@
 import re
 import optparse
+import utils
+from os import path
 
 
 def clean_corpus(corpus):
@@ -83,16 +85,25 @@ if __name__ == '__main__':
     parser = optparse.OptionParser()
     parser.add_option('-f', '--file', dest='input_file', default=None, help='Specify source data file')
     parser.add_option('-o', '--output_file', dest='output_file', default="output.txt", help="Specify output data file.")
+    parser.add_option('-d', '--run_directory', dest="run_directory", default=None, help="Specify the directory name where all ingested corpus files reside.")
     parser.add_option('-s', '--min_sentence_length', dest='sentence_length', default=10, help="Specify minimum sentence word length.")
     (opts, args) = parser.parse_args()
 
-    with open(opts.input_file, "rb") as f:
-        corpus = f.read()
+    if opts.input_file:
+        with open(opts.input_file, "rb") as f:
+            corpus = f.read()
+        # TODO: is this the default functionality we want for single files?
+        output_file = opts.output_file
+    if opts.run_directory:
+        # specify the output file
+        output_file = path.join(utils.PARENT_DIR, 'data', opts.run_directory, opts.output_file)
+        # clean all the files, compress them into a single file, write to output_file
+        corpus = utils.read_source(opts.run_directory, source_type="corpus")
 
     cleaned_corpus = clean_corpus(corpus)
     tokenized_corpus = tokenize_sentences(cleaned_corpus)
     cleaned_sentences = validate_sentences(tokenized_corpus, opts.sentence_length)
 
-    with open(opts.output_file, "wb") as f:
-        blob = ' '.join(cleaned_sentences)
+    with open(output_file, "wb") as f:
+        blob = '\n'.join(cleaned_sentences)
         f.write(blob)

--- a/fun_3000/wrangling/clean_corpus.py
+++ b/fun_3000/wrangling/clean_corpus.py
@@ -97,7 +97,8 @@ if __name__ == '__main__':
     if opts.run_directory:
         # specify the output file
         output_file = path.join(utils.PARENT_DIR, 'data', opts.run_directory, opts.output_file)
-        # clean all the files, compress them into a single file, write to output_file
+        # TODO: pulls entire directory of corpus data into a single string
+        # probably want to stream this instead l8r
         corpus = utils.read_source(opts.run_directory, source_type="corpus")
 
     cleaned_corpus = clean_corpus(corpus)

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -25,8 +25,6 @@ def generate_word2vec_folds(corpus='Empty', folds=3, seed=10, min_sentence_lengt
     :return:
     '''
 
-    # Tokenize the corpus into sentences because we need to get a random sample of sentences from the resulting list.
-    tokenized_corpus=tokenize_sentences(corpus)
     #tokenize the corpus into sentences because we need to get a random sample of sentences from the resulting list.
     cleaned_corpus= clean_corpus(corpus) #remove random characters from corpus
 

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -25,7 +25,6 @@ def generate_word2vec_folds(corpus=[], folds=3, seed=10, min_sentence_length=10)
     '''
 
     tokenized_corpus=np.array(corpus)
-    import pdb;pdb.set_trace()
 
     number_of_sentences=len(tokenized_corpus)
 

--- a/fun_3000/wrangling/generate_folds.py
+++ b/fun_3000/wrangling/generate_folds.py
@@ -133,6 +133,9 @@ def run(run_directory, corpus_filename="output.txt", ontology_flag=False, k=5, s
     # figure out where the corpus file is. should be in ddl_nlp/data/{run_directory}/{corpus_filename}
     absolute_corpus_filename = path.join(PARENT_DIR, 'data', run_directory, corpus_filename)
     with io.open(absolute_corpus_filename, "rt") as f:
+        # TODO: right now this reads the entire corpus into a list at once
+        # we probably want to change this into a generator later so we can stream this information
+        # but we have to address how to random sample a generator in generate_folds.py to do so
         corpus = []
         for line in f.readlines():
             corpus.append(line)

--- a/fun_3000/wrangling/utils.py
+++ b/fun_3000/wrangling/utils.py
@@ -1,0 +1,41 @@
+import sys
+from os import path, listdir
+
+# TODO: SUPER FRAGILE for this to be in a utils file especially if we move this
+# drama
+CURRENT_DIR = path.dirname(path.realpath(__file__))
+PARENT_DIR = path.abspath(path.join(CURRENT_DIR, '../..'))
+
+
+def read_source(run_directory, source_type):
+    """
+    Reads a set of source files in an input_data_dir and generates a single string from those input files.
+    :param run_directory: The subject name of the test. For example 'run1' or 'medical', etc.
+    :type run_directory: str
+    :param source_type: Either 'corpus' or 'ontology'.
+    :type source_type: str
+    :return: concatenated string of all the files in the source directory
+    :rtype: str
+    """
+    # Figure out data directory
+
+    if source_type == 'corpus':
+        data_dir = path.join(PARENT_DIR, 'data', run_directory)
+    elif source_type == 'ontology':
+        data_dir = path.join(PARENT_DIR, 'ontologies', run_directory)
+
+    # Below grabs all of the files in the current model directory and builds a single string corpus out of them.  This
+    # avoids the sub-directories if they exist.
+    input_data = ''
+    if path.exists(data_dir):
+        for some_corpus_file in listdir(data_dir):
+            if path.isfile(path.join(data_dir, some_corpus_file)):
+                with open(path.join(data_dir, some_corpus_file),'rb') as infile:
+                    new_file_data = infile.read()
+                    input_data = ''.join((input_data, new_file_data))
+
+        return input_data
+
+    else:
+        print 'Could not find the data/ontology directory: ', data_dir
+        sys.exit(0)


### PR DESCRIPTION
## Background

Closes #54. We wanted to be able to not keep doing the clean corpus steps over and over during `generate_folds.py` since it technically doesn't need to be so tightly coupled.
## Implementation Notes:

I broke out the function for `read_source` that knows a bunch of specifics about our directory structure and where to find corpus files vs ontology files. Since the path discovery settings are executed as part of that file, if this `utils` file is ever moved we will have to change up how it discovers paths. Actually I think we should fix the way we address path discovery for the entire project at some point, with this being one of the issues to get over.
## Testing

Reproduce:
Back in the day, you would run ingestion, and then just run `drake`, and a bunch of cleaning stuff would happen at the same time.

Fixed:
Now we expect users to clean corpus ahead of time. In this case, after ingestion you would run, for example if your ingestion directory is `run1`:
`python clean_corpus.py -d run1`
This will put a file at `ddl_nlp/data/run1/output.txt` that is the cleaned, newline delimited version of the corpus text. Check that file and confirm.

Now, assuming everything meets the `Drakefile` defaults, you should be able to run `drake` with no problems.

If you want to test our changes to `generate_folds.py` specifically, again if your ingestion directory is `run1` and you used the default output filename for `clean_corpus.py`, then you can run:
`python generate_folds.py -f output.txt -d run1 -o`
And see that folds are generated off your cleaned corpus file instead of using the directory.
