### PR TITLE
Fix/change Drake file dependencies so step caching works and we aren't tracking excess files

### DIFF
--- a/Drakefile
+++ b/Drakefile
@@ -15,23 +15,19 @@ SCORING_OUTPUT_FILE=scores.csv
 ; Don't change this EV..ER
 FUN_3000_DIR=fun_3000
 
-; Set up workflow artifact directory
-workflow/00.setup.complete <- [shell]
-    mkdir -p workflow/
-    touch $OUTPUT
 
 ; Using pre-cleaned data, append ontologies a user-specified number of times, and place in the proper file structure. 
-workflow/01.boost_corpus_with_ontology.complete <- workflow/00.setup.complete [shell]
-    python $[FUN_3000_DIR]/wrangling/boost_corpus_with_ontology.py -d $[INPUT_DATA_DIR] -f $[CORPUS_FILENAME] -m $[MULTIPLIER] && touch $OUTPUT
+%boosted, data/$[INPUT_DATA_DIR]/$[MULTIPLIER]_boost_$[CORPUS_FILENAME] <- data/$[INPUT_DATA_DIR]/$[CORPUS_FILENAME] [shell]
+    python $[FUN_3000_DIR]/wrangling/boost_corpus_with_ontology.py -d $[INPUT_DATA_DIR] -f $[CORPUS_FILENAME] -m $[MULTIPLIER]
 
 ; Run Gensim word2vec on the corpus
-workflow/02.model.complete <- workflow/01.boost_corpus_with_ontology.complete [shell]
-    python $[FUN_3000_DIR]/word2vec.py -d $[INPUT_DATA_DIR] -f $[CORPUS_FILENAME] -p $[PARALLEL_THREADS] -l $[HIDDEN_LAYER_SIZE] -w $[WINDOW_SIZE] && touch $OUTPUT
+%model_built, data/$[INPUT_DATA_DIR]/$[INPUT_DATA_DIR].model <- data/$[INPUT_DATA_DIR]/$[MULTIPLIER]_boost_$[CORPUS_FILENAME] [shell]
+    python $[FUN_3000_DIR]/word2vec.py -d $[INPUT_DATA_DIR] -f $[CORPUS_FILENAME] -p $[PARALLEL_THREADS] -l $[HIDDEN_LAYER_SIZE] -w $[WINDOW_SIZE]
 ; @Laura : how do we reference the output from the previous step of the workflow?? :(
 
 ; Run Evaluation
-workflow/03.evaluate.complete <- workflow/02.model.complete [shell]
-    python $[FUN_3000_DIR]/evaluation/similarity_evaluation.py -r $[INPUT_DATA_DIR] -o $[SCORING_OUTPUT_FILE] -m $[MULTIPLIER] && touch $OUTPUT
+$[SCORING_OUTPUT_FILE] <- data/$[INPUT_DATA_DIR]/$[INPUT_DATA_DIR].model [shell]
+    python $[FUN_3000_DIR]/evaluation/similarity_evaluation.py -r $[INPUT_DATA_DIR] -o $[SCORING_OUTPUT_FILE] -m $[MULTIPLIER]
 ; @David is editing this file, so need to come back to this after.
 
 ; Add viz step?


### PR DESCRIPTION
The Drakefile was kinda broken before in the sense that  no matter which steps we had already run, all of the steps would always run despite the input files already existing. This PR changes the Drakefile input and outputs so that instead of tracking external workflow files its paying attention to the actual files our python scripts create. I think we could have still left it the other way and fixed it but this felt more natural and "Drake"y. I also took out the models directory since our refactor makes that obsolete, as models will be saved in the data/{data_dir} directory now.

You can recreate the issue by, on the **master** branch:
1) running `drake` (evaluation won't work properly but that is a known bug)
2) running `drake` again and see that it tries to do ALL the steps again even though it already just did them

You can test this by
1) making sure your data_dir (e.g. data/run1) doesn't have a `.model` file in it but does have its cleaned corpus `output.txt` in it
2) running `drake` (evaluation will break but that is expected since it hasn't been fixed yet)
3) running `drake` again and it should say it has nothing to do
4) force run `drake` through model building with `drake +%model_built`
5) run `drake` again and it should know it should run just the evaluation step because the timestamp on its input file has changed due to step 4