### PR TITLE
Issue 56: adding the visualizations

### DIFF
--- a/fun_3000/evaluation/visualize_scores.py
+++ b/fun_3000/evaluation/visualize_scores.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import numpy as np
+import seaborn as sns
+
+def main(fname):
+    # comments here
+    df = pd.read_csv(fname)
+    eval_factorplot(df)
+    # eval_boxplot(df)
+    eval_swarmplot(df)
+
+
+
+def eval_factorplot(df):
+    xname = "Boost_level"
+    yname = "Score"
+    sns.factorplot(data=df, x=xname, y=yname)
+    sns.plt.show()
+
+
+def eval_boxplot(df):
+    xname = "Boost_level"
+    yname = "Score"
+    sns.boxplot(x=xname, y=yname, data=df)
+    sns.plt.show()
+
+def eval_swarmplot(df):
+    xname = "Boost_level"
+    yname = "Score"
+    sns.boxplot(x=xname, y=yname, data=df)
+    sns.swarmplot(x=xname, y=yname, data=df, color=".25")
+    sns.plt.show()
+
+
+
+
+
+
+if __name__ == '__main__':
+    fname = '../../scores.csv'
+    main(fname)

--- a/fun_3000/word2vec.py
+++ b/fun_3000/word2vec.py
@@ -58,4 +58,4 @@ if __name__ == '__main__':
 
     (opts, args) = parser.parse_args()
 
-    run_model(opts.data_directory, opts.input_filename, opts.parallel_workers, opts.context_window, opts.hidden_layer)
+    run_model(opts.data_directory, opts.input_filename, opts.parallel_workers, opts.hidden_layer, opts.context_window)


### PR DESCRIPTION
I added the visualize_scores.py to the evaluation folder. It creates a dataframe out of the scores.csv and creates 3 different plots. I used seaborn for the plots but I didn't update the requirements.txt file because when i was installing seaborn, it installed other dependencies which I am not sure we need. I used seaborn 0.7.1. Perhaps we can add that to the requirements.txt to test. 

I also update the run_model call in the word2vec.py. I realized that it's expecting the hidden_layer and the context_window arguments to be flipped. 

I didn't create the link in the drakefile because I am not drake savy and didn't know the syntax. I could follow the python syntax but was unsure about this part:
workflow/03.evaluate.complete <- workflow/02.model.complete [shell]

Attached is the scores.csv that i created with fake data in order to test
[scores.csv.zip](https://github.com/ayota/ddl_nlp/files/743636/scores.csv.zip)

