### PR TITLE
pin htmllib to the "seven 9's" version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ wikipedia==1.4.0
 pandas==0.17.1
 xmltodict==0.9.2
 biopython==1.66
+html5lib==0.9999999


### PR DESCRIPTION
adding the right version of htmllib. forgot the deets but this used to be problematic. I actually forget why but this was a debugging step I had to go through with @lempira and my local version is on this version so I think we should just get it in ;)

You can run this by starting a new virtualenv or conda environment and do a clean install of these requirements with `pip install -r requirements.txt` and give the drakefile a run (assuming you have a file in data/run1/output.txt) by running `drake` and make sure errybody fine